### PR TITLE
Subscriptions - multiple topic support (#629)

### DIFF
--- a/guides/subscriptions.md
+++ b/guides/subscriptions.md
@@ -126,6 +126,9 @@ subscription do
     # subscription {
     #   commentAdded(repoName: "elixir-lang/elixir") { content }
     # }
+    #
+    # If needed, you can also provide a list of topics:
+    #   {:ok, topic: ["absinthe-graphql/absinthe", "elixir-lang/elixir"]}
     config fn args, _ ->
       {:ok, topic: args.repo_name}
     end

--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -49,7 +49,9 @@ defmodule Absinthe.Schema.Notation do
   @doc """
   Configure a subscription field.
 
-  ## Example
+  The returned topic can be single topic, or a list of topics
+
+  ## Examples
 
   ```elixir
   config fn args, %{context: context} ->
@@ -58,6 +60,14 @@ defmodule Absinthe.Schema.Notation do
     else
       {:error, "unauthorized"}
     end
+  end
+  ```
+
+  Alternatively can provide a list of topics:
+
+  ```elixir
+  config fn _, _ ->
+    {:ok, topic: ["topic_one", "topic_two", "topic_three"]}
   end
   ```
 

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -97,6 +97,12 @@ defmodule Absinthe.Execution.SubscriptionTest do
             }
         end
       end
+
+      field :multiple_topics, :string do
+        config fn _, _ ->
+          {:ok, topic: ["topic_1", "topic_2", "topic_3"]}
+        end
+      end
     end
   end
 
@@ -131,6 +137,93 @@ defmodule Absinthe.Execution.SubscriptionTest do
              result: %{data: %{"thing" => "foo"}},
              topic: topic
            } == msg
+  end
+
+  @query """
+  subscription ($clientId: ID!) {
+    thing(clientId: $clientId)
+  }
+  """
+  test "can unsubscribe the current process" do
+    client_id = "abc"
+
+    assert {:ok, %{"subscribed" => topic}} =
+             run(
+               @query,
+               Schema,
+               variables: %{"clientId" => client_id},
+               context: %{pubsub: PubSub}
+             )
+
+    Absinthe.Subscription.unsubscribe(PubSub, topic)
+
+    Absinthe.Subscription.publish(PubSub, "foo", thing: client_id)
+
+    refute_receive({:broadcast, _})
+  end
+
+  @query """
+  subscription {
+    multipleTopics
+  }
+  """
+  test "schema can provide multiple topics to subscribe to" do
+    assert {:ok, %{"subscribed" => topic}} =
+             run(
+               @query,
+               Schema,
+               variables: %{},
+               context: %{pubsub: PubSub}
+             )
+
+
+    msg = %{
+             event: "subscription:data",
+             result: %{data: %{"multipleTopics" => "foo"}},
+             topic: topic
+           }
+
+    Absinthe.Subscription.publish(PubSub, "foo", multiple_topics: "topic_1")
+
+    assert_receive({:broadcast, ^msg})
+
+    Absinthe.Subscription.publish(PubSub, "foo", multiple_topics: "topic_2")
+
+    assert_receive({:broadcast, ^msg})
+
+    Absinthe.Subscription.publish(PubSub, "foo", multiple_topics: "topic_3")
+
+    assert_receive({:broadcast, ^msg})
+  end
+
+
+  @query """
+  subscription {
+    multipleTopics
+  }
+  """
+  test "unsubscription works when multiple topics are provided" do
+    assert {:ok, %{"subscribed" => topic}} =
+             run(
+               @query,
+               Schema,
+               variables: %{},
+               context: %{pubsub: PubSub}
+             )
+
+    Absinthe.Subscription.unsubscribe(PubSub, topic)
+
+    Absinthe.Subscription.publish(PubSub, "foo", multiple_topics: "topic_1")
+
+    refute_receive({:broadcast, _})
+
+    Absinthe.Subscription.publish(PubSub, "foo", multiple_topics: "topic_2")
+
+    refute_receive({:broadcast, _})
+
+    Absinthe.Subscription.publish(PubSub, "foo", multiple_topics: "topic_3")
+
+    refute_receive({:broadcast, _})
   end
 
   @query """


### PR DESCRIPTION
* Subscriptions: support multiple topics

Subscription `config` function can now provide multiple topics by
providing a list (`{:ok, topic: ["topic_1", "topic_2"]}`). Providing
a single topic (`{:ok, topic: "topic_1"}`) is still supported as well.

* Add tests for subscription multiple topic support

* Update docs for subscribing to multiple topic

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
